### PR TITLE
make setup.py and requirements.txt compatible with newer pip versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 pandas
 numba
-psycopg2
+# As this list is commonly passed to pip, use the package that can also be installed from pip..
+psycopg2-binary
 scikit-learn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,18 @@ try:
     from setuptools import setup, find_packages
 except ImportError:
     from distutils.core import setup, find_packages
-try: # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-    from pip.req import parse_requirements
 
-install_reqs = parse_requirements('requirements.txt', session=False)
-reqs = [str(ir.req) for ir in install_reqs]
-dep_links = [str(req_line.url) for req_line in install_reqs]
 
+def parse_requirements(filename):
+    with open(filename, "r") as file:
+        lines = (line.strip() for line in file)
+        return [line for line in lines if line and not line.startswith("#")]
+
+
+reqs = parse_requirements("requirements.txt")
+dep_links = [url for url in reqs if "http" in url]
+reqs = [req for req in reqs if "http" not in req]
+reqs += [url.split("egg=")[-1] for url in dep_links if "egg=" in url]
 
 setup(
     name='bb_circadian',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='BeesBook circadian behaviour analysis',
     author='David Dormagen',
     author_email='david.dormagen@fu-berlin.de',
-    url='https://github.com/walachey/bb_circadian/',
+    url='https://github.com/BioroboticsLab/bb_circadian/',
     install_requires=reqs,
     dependency_links=dep_links,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='BeesBook circadian behaviour analysis',
     author='David Dormagen',
     author_email='david.dormagen@fu-berlin.de',
-    url='https://github.com/walachey/bb_circadian/',
+    url='https://github.com/Juliamelle01/bb_circadian/',
     install_requires=reqs,
     dependency_links=dep_links,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='BeesBook circadian behaviour analysis',
     author='David Dormagen',
     author_email='david.dormagen@fu-berlin.de',
-    url='https://github.com/Juliamelle01/bb_circadian/',
+    url='https://github.com/walachey/bb_circadian/',
     install_requires=reqs,
     dependency_links=dep_links,
     packages=find_packages(),


### PR DESCRIPTION
* changed setup.py so parse_requirements works again
* change requirements as psycopg2 should be installed as psycopg2-binary otherwise  erorr occurs